### PR TITLE
Fix issue where values could be imputed that violate rules.

### DIFF
--- a/pkg/inst/tinytest/test_linimpute.R
+++ b/pkg/inst/tinytest/test_linimpute.R
@@ -98,9 +98,8 @@ expect_equivalent(
     1,NA,NA,1,
     NA,1,1,2
   ),ncol=2)
-  attr(X,"changed") <- FALSE
   out <- matrix(c(1,0,0,1, NA,1,1,2),ncol=2)
-  attr(out,"changed") <- TRUE
+  attr(out, "changed") <- c(TRUE, FALSE)
   lc <- v$linear_coefficients()
   expect_equal(
     deductive:::zeroimpute(A=lc$A, b=lc$b, ops=lc$operators, x=X)
@@ -209,5 +208,9 @@ r <- validator(.file="lr_fm_rules.yml")
 expect_true( all(confront(impute_lr(d,r, methods="implied"), r), na.rm=TRUE))
 expect_true( all(confront(impute_lr(d,r, methods="fm"), r), na.rm=TRUE))
 
-
-
+## test imputation of value in infeasible system.
+#  the value a = -2 must not be imputed in the first record.
+rules <- validator(a >= 0, a + b == c)
+d_in <- data.frame(a = c(NA_real_, NA_real_, NA_real_), b = c(10, 10, 10), c = c(8, 10, 12))
+d_out <- data.frame(a = c(NA_real_, 0, 2), b = c(10, 10, 10), c = c(8, 10, 12))
+expect_equal(impute_lr(d_in, rules), d_out)

--- a/pkg/src/imputezero.c
+++ b/pkg/src/imputezero.c
@@ -83,11 +83,7 @@ SEXP R_imputezero(SEXP A_, SEXP b_, SEXP X_, SEXP nonneg_, SEXP eps_ ){
   double *A = REAL(A_);
   double *b = REAL(b_);
   double eps = REAL(eps_)[0];
-
   int *nonneg = INTEGER(nonneg_);
-  SEXP changed =  PROTECT(allocVector(LGLSXP,1L));
-  int *ch = INTEGER(changed);
-  ch[0] = 0;
 
   int dim[2];
   rdim(A_, dim);
@@ -95,14 +91,18 @@ SEXP R_imputezero(SEXP A_, SEXP b_, SEXP X_, SEXP nonneg_, SEXP eps_ ){
     , colsA = dim[1];
   rdim(XC,dim);
   int nx = dim[1];  
+
+  SEXP changed =  PROTECT(allocVector(LGLSXP, nx));
+  int *ch = INTEGER(changed);
  
   double *a;
   a = (double *) malloc(sizeof(double) * colsA);
   double *x = REAL(XC);
   for ( int k=0; k < nx; k++ ){
+    ch[k] = 0;
     for ( int i=0; i < rowsA; i++){
       for ( int j=0; j < colsA; j++) a[j] = A[j*rowsA + i];
-      ch[0] = ch[0] | impute_zero(a, b[i], colsA, nonneg, eps, x);
+      ch[k] |= impute_zero(a, b[i], colsA, nonneg, eps, x);
     }
     x += colsA;
   }


### PR DESCRIPTION
Imputations functions that base imputed values on a subset of the rules (e.g., only equalities) could lead to imputed values that violdate other rules. This fix checks the imputed values and discards changes to any records that would lead to new rule violations.